### PR TITLE
Change the cascade wait to use checks

### DIFF
--- a/command/wait.go
+++ b/command/wait.go
@@ -56,7 +56,7 @@ func waitFor(serviceName string) error {
 	// Setup watch
 	watchParams := make(map[string]interface{})
 
-	watchParams["type"] = "service"
+	watchParams["type"] = "checks"
 	watchParams["service"] = serviceName
 
 	theWatch, err := watch.Parse(watchParams)
@@ -65,10 +65,11 @@ func waitFor(serviceName string) error {
 	}
 
 	theWatch.Handler = func(idx uint64, data interface{}) {
-		services := data.([]*api.ServiceEntry)
+		services := data.([]*api.HealthCheck)
+
 		for _, service := range services {
-			fmt.Println(service.Service.ID + " = " + service.Checks.AggregatedStatus())
-			if service.Checks.AggregatedStatus() == api.HealthPassing {
+			if service.Status == api.HealthPassing {
+				fmt.Println("passing: " + service.ServiceID)
 				theWatch.Stop()
 			}
 		}

--- a/command/wait.go
+++ b/command/wait.go
@@ -65,13 +65,22 @@ func waitFor(serviceName string) error {
 	}
 
 	theWatch.Handler = func(idx uint64, data interface{}) {
-		services := data.([]*api.HealthCheck)
+		checks := data.([]*api.HealthCheck)
 
-		for _, service := range services {
-			if service.Status == api.HealthPassing {
-				fmt.Println("passing: " + service.ServiceID)
-				theWatch.Stop()
+		passedCount := 0
+		for _, check := range checks {
+			if check.Status == api.HealthPassing {
+				fmt.Println("passing: " + check.CheckID)
+				passedCount ++
+			} else {
+				fmt.Println("not passing: " + check.CheckID)
 			}
+		}
+
+		totalCount := len(checks)
+		if totalCount > 0 && passedCount == totalCount {
+			fmt.Println("all passing")
+			theWatch.Stop()
 		}
 	}
 


### PR DESCRIPTION
before the cascade wait will check on /v1/health/service which will include the system checks like Disk Space check defined in consul. If any of the checks return passing, it will stop wait.

the problem is that when Disk Space check return passing, the actual service itself may not pass the health check. so the depended service may not start correctly.

The fix is to use /v1/health/checks to only include the health checks defined by the service. Also added logic to make sure all the checks passed before we continue.

@codemoran 